### PR TITLE
Explain advantages of PostgreSQL large objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ PostgreSQL databases.
 * Extensions to Ecto query DSL for interacting with large objects as part of
   Ecto queries.
 
+## Why Use Large Objects?
+
+An application wishing to store larger amounts of data typically has two options for doing so:
+
+1. A new column on some table can be introduced; Postgres features a `bytea` type for this purpose. This is easy to implement but suffers from requiring to hold the complete data in memory when reading or writing, something which may not be viable beyond a few dozen megabytes. Efficient streaming or random-access operations are not practical.
+2. A separate cloud storage (e.g. AWS S3) could be used. This permits streaming but requires complicating the tech stack by depending on a new service. Bridging the two systems (e.g. ‘Delete all uploads for a given user ID’) requires Elixir support.
+
+PostgreSQL features a ‘large objects’ facility which enables efficient streaming access to large (up to 4TB) files. This solves these problems:
+
+1. Unlike values in table columns, large objects can be streamed into/out of the database and permit random access operations.
+2. Unlike e.g. S3, no new technology is needed. Large objects live side-by-side with the tables referencing them, operations like ‘Delete all uploads for a given user ID’ are just one `SELECT` statement.
+
 ## Installation
 
 Install the package by adding `pg_large_objects` to your list of dependencies


### PR DESCRIPTION
Added section explaining the benefits of using PostgreSQL large objects, taken from Frerich's explanation in Elixir Slack. This deserves to be in the docs! :)