### PR TITLE
fix: forward bufsize option in export/3 recursive call

### DIFF
--- a/lib/pg_large_objects.ex
+++ b/lib/pg_large_objects.ex
@@ -96,7 +96,11 @@ defmodule PgLargeObjects do
         {:ok, buffer} = StringIO.open("", encoding: :latin1)
 
         result =
-          with :ok <- export(repo, oid, into: IO.binstream(buffer, opts[:bufsize]), bufsize: opts[:bufsize]) do
+          with :ok <-
+                 export(repo, oid,
+                   into: IO.binstream(buffer, opts[:bufsize]),
+                   bufsize: opts[:bufsize]
+                 ) do
             {_input, output} = StringIO.contents(buffer)
             {:ok, output}
           end

--- a/lib/pg_large_objects.ex
+++ b/lib/pg_large_objects.ex
@@ -96,7 +96,7 @@ defmodule PgLargeObjects do
         {:ok, buffer} = StringIO.open("", encoding: :latin1)
 
         result =
-          with :ok <- export(repo, oid, into: IO.binstream(buffer, opts[:bufsize])) do
+          with :ok <- export(repo, oid, into: IO.binstream(buffer, opts[:bufsize]), bufsize: opts[:bufsize]) do
             {_input, output} = StringIO.contents(buffer)
             {:ok, output}
           end


### PR DESCRIPTION
  When export/3 is called without :into, it opens a StringIO buffer and
  recurses with into: set. The bufsize option was not forwarded, causing
  LargeObject.open/3 to silently fall back to the 65_536 default instead
  of using the configured value.