### PR TITLE
Try to let Dependabot group PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      patch-updates:
+        update-types: [ "patch" ]
+      minor-updates:
+        update-types: [ "minor" ]
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Mix updates seem to come in waves, but having a bazillion separate PRs and resolving conflicts because they all modify `mix.lock` is annoying. Let's follow the example given at

  https://www.jacobras.nl/2025/03/code-snippet-grouping-dependabot-prs/

and make use of Dependabot's ability to group changes such that:

* All patch-level releases are grouped into one PR
* All minor-level releases are grouped into one PR
* Any major-level releases get one PR per dependency (these are probably more delicate)

Also, permit five open Dependabot PRs in total, so that means that we'll have at most

* One PR for any patch-level updates
* One PR for any minor-level updates
* Three PRs for three major-level updates